### PR TITLE
IOSXR Prefix-listを参照するpolicy-statementの処理を更新

### DIFF
--- a/test/expects/cisco_ios_xr/policy_model.json
+++ b/test/expects/cisco_ios_xr/policy_model.json
@@ -1,19 +1,6 @@
 {
-  "node": "192.168.255.7",
+  "node": "192.168.255.2",
   "prefix-set": [
-    {
-      "name": "as65550-advd",
-      "prefixes": [
-        {
-          "prefix": "10.100.0.0/16",
-          "match-type": "exact",
-          "length": {
-            "min": "16",
-            "max": "16"
-          }
-        }
-      ]
-    },
     {
       "name": "default-ipv4",
       "prefixes": [
@@ -39,6 +26,80 @@
           }
         }
       ]
+    },
+    {
+      "name": "as65550-advd-ipv4",
+      "prefixes": [
+        {
+          "prefix": "10.100.0.0/16",
+          "match-type": "exact",
+          "length": {
+            "min": "16",
+            "max": "16"
+          }
+        },
+        {
+          "prefix": "10.110.0.0/20",
+          "match-type": "exact",
+          "length": {
+            "min": "20",
+            "max": "20"
+          }
+        },
+        {
+          "prefix": "10.120.0.0/17",
+          "match-type": "exact",
+          "length": {
+            "min": "17",
+            "max": "17"
+          }
+        },
+        {
+          "prefix": "10.130.0.0/21",
+          "match-type": "exact",
+          "length": {
+            "min": "21",
+            "max": "21"
+          }
+        }
+      ]
+    },
+    {
+      "name": "as65560-advd-ipv4",
+      "prefixes": [
+        {
+          "prefix": "10.100.0.0/16",
+          "match-type": "exact",
+          "length": {
+            "min": "16",
+            "max": "16"
+          }
+        },
+        {
+          "prefix": "10.110.0.0/20",
+          "match-type": "exact",
+          "length": {
+            "min": "20",
+            "max": "20"
+          }
+        },
+        {
+          "prefix": "10.120.0.0/17",
+          "match-type": "exact",
+          "length": {
+            "min": "17",
+            "max": "17"
+          }
+        },
+        {
+          "prefix": "10.130.0.0/21",
+          "match-type": "exact",
+          "length": {
+            "min": "21",
+            "max": "21"
+          }
+        }
+      ]
     }
   ],
   "as-path-set": [
@@ -52,24 +113,20 @@
       ]
     },
     {
-      "group-name": "multiple-regex",
-      "as-path": [
-        {
-          "name": "multiple-regex_1",
-          "pattern": "^(65001 )+$"
-        },
-        {
-          "name": "multiple-regex_2",
-          "pattern": "^(65002 )+$"
-        }
-      ]
-    },
-    {
       "group-name": "as65550-origin",
       "as-path": [
         {
           "name": "as65550-origin_1",
           "pattern": "^(65550 )+$"
+        }
+      ]
+    },
+    {
+      "group-name": "as65560-origin",
+      "as-path": [
+        {
+          "name": "as65560-origin_1",
+          "pattern": "^(65560 )+$"
         }
       ]
     },
@@ -135,14 +192,6 @@
           "name": "POI-East_in-10",
           "conditions": [],
           "actions": [
-            {
-              "as-path-prepend": [
-                {
-                  "asn": "50000",
-                  "repeat": 2
-                }
-              ]
-            },
             {
               "metric": "100"
             },
@@ -235,14 +284,7 @@
           "name": "10",
           "conditions": [
             {
-              "route-filter": {
-                "prefix": "0.0.0.0/0",
-                "match-type": "exact",
-                "length": {
-                  "min": "0",
-                  "max": "0"
-                }
-              }
+              "prefix-list": "default-ipv4"
             }
           ],
           "actions": [
@@ -455,14 +497,7 @@
           "name": "10",
           "conditions": [
             {
-              "route-filter": {
-                "prefix": "0.0.0.0/0",
-                "match-type": "exact",
-                "length": {
-                  "min": "0",
-                  "max": "0"
-                }
-              }
+              "prefix-list": "default-ipv4"
             }
           ],
           "actions": [
@@ -669,14 +704,6 @@
           ],
           "actions": [
             {
-              "as-path-prepend": [
-                {
-                  "asn": "60000",
-                  "repeat": 1
-                }
-              ]
-            },
-            {
               "local-preference": "300"
             },
             {
@@ -742,6 +769,9 @@
               "community": [
                 "aggregate"
               ]
+            },
+            {
+              "prefix-list": "as65550-advd-ipv4"
             }
           ],
           "actions": [
@@ -788,6 +818,15 @@
       "name": "as65550-peer-out1-tyo-ipv4",
       "statements": [
         {
+          "name": "_generated_next-hop-self",
+          "conditions": [],
+          "actions": [
+            {
+              "next-hop": "self"
+            }
+          ]
+        },
+        {
           "name": "as65550-peer-out1-tyo-ipv4-10",
           "conditions": [],
           "actions": [
@@ -833,25 +872,13 @@
       }
     },
     {
-      "name": "if-condition-as65550-peer-out2-tyo-ipv4-20",
+      "name": "if-condition-as65560-peer-in1-tyo-ipv4-20",
       "statements": [
         {
           "name": "10",
           "conditions": [
             {
-              "community": [
-                "aggregate"
-              ]
-            },
-            {
-              "route-filter": {
-                "prefix": "10.100.0.0/16",
-                "match-type": "exact",
-                "length": {
-                  "min": "16",
-                  "max": "16"
-                }
-              }
+              "as-path-group": "as65560-origin"
             }
           ],
           "actions": [
@@ -870,13 +897,13 @@
       }
     },
     {
-      "name": "not-if-condition-as65550-peer-out2-tyo-ipv4-20",
+      "name": "not-if-condition-as65560-peer-in1-tyo-ipv4-20",
       "statements": [
         {
           "name": "10",
           "conditions": [
             {
-              "policy": "if-condition-as65550-peer-out2-tyo-ipv4-20"
+              "policy": "if-condition-as65560-peer-in1-tyo-ipv4-20"
             }
           ],
           "actions": [
@@ -895,10 +922,200 @@
       }
     },
     {
-      "name": "as65550-peer-out2-tyo-ipv4",
+      "name": "if-condition-as65560-peer-in1-tyo-ipv4-30",
       "statements": [
         {
-          "name": "as65550-peer-out2-tyo-ipv4-10",
+          "name": "10",
+          "conditions": [
+            {
+              "as-path-group": "any"
+            }
+          ],
+          "actions": [
+            {
+              "target": "accept"
+            }
+          ]
+        }
+      ],
+      "default": {
+        "actions": [
+          {
+            "target": "reject"
+          }
+        ]
+      }
+    },
+    {
+      "name": "not-if-condition-as65560-peer-in1-tyo-ipv4-30",
+      "statements": [
+        {
+          "name": "10",
+          "conditions": [
+            {
+              "policy": "if-condition-as65560-peer-in1-tyo-ipv4-30"
+            }
+          ],
+          "actions": [
+            {
+              "target": "reject"
+            }
+          ]
+        }
+      ],
+      "default": {
+        "actions": [
+          {
+            "target": "accept"
+          }
+        ]
+      }
+    },
+    {
+      "name": "as65560-peer-in1-tyo-ipv4",
+      "statements": [
+        {
+          "name": "as65560-peer-in1-tyo-ipv4-10",
+          "conditions": [],
+          "actions": [
+            {
+              "apply": "reject-in-ipv4"
+            }
+          ]
+        },
+        {
+          "name": "as65560-peer-in1-tyo-ipv4-20",
+          "conditions": [
+            {
+              "policy": "if-condition-as65560-peer-in1-tyo-ipv4-20"
+            }
+          ],
+          "actions": [
+            {
+              "local-preference": "300"
+            },
+            {
+              "metric": "100"
+            },
+            {
+              "community": {
+                "action": "set",
+                "name": "peer"
+              }
+            },
+            {
+              "target": "accept"
+            }
+          ]
+        },
+        {
+          "name": "as65560-peer-in1-tyo-ipv4-30",
+          "conditions": [
+            {
+              "policy": "if-condition-as65560-peer-in1-tyo-ipv4-30"
+            }
+          ],
+          "actions": [
+            {
+              "local-preference": "210"
+            },
+            {
+              "metric": "100"
+            },
+            {
+              "community": {
+                "action": "set",
+                "name": "peer"
+              }
+            },
+            {
+              "target": "accept"
+            }
+          ]
+        },
+        {
+          "name": "as65560-peer-in1-tyo-ipv4-40",
+          "conditions": [],
+          "actions": [
+            {
+              "target": "reject"
+            }
+          ]
+        }
+      ],
+      "default": {
+        "actions": []
+      }
+    },
+    {
+      "name": "if-condition-as65560-peer-out1-tyo-ipv4-20",
+      "statements": [
+        {
+          "name": "10",
+          "conditions": [
+            {
+              "community": [
+                "aggregate"
+              ]
+            },
+            {
+              "prefix-list": "as65560-advd-ipv4"
+            }
+          ],
+          "actions": [
+            {
+              "target": "accept"
+            }
+          ]
+        }
+      ],
+      "default": {
+        "actions": [
+          {
+            "target": "reject"
+          }
+        ]
+      }
+    },
+    {
+      "name": "not-if-condition-as65560-peer-out1-tyo-ipv4-20",
+      "statements": [
+        {
+          "name": "10",
+          "conditions": [
+            {
+              "policy": "if-condition-as65560-peer-out1-tyo-ipv4-20"
+            }
+          ],
+          "actions": [
+            {
+              "target": "reject"
+            }
+          ]
+        }
+      ],
+      "default": {
+        "actions": [
+          {
+            "target": "accept"
+          }
+        ]
+      }
+    },
+    {
+      "name": "as65560-peer-out1-tyo-ipv4",
+      "statements": [
+        {
+          "name": "_generated_next-hop-self",
+          "conditions": [],
+          "actions": [
+            {
+              "next-hop": "self"
+            }
+          ]
+        },
+        {
+          "name": "as65560-peer-out1-tyo-ipv4-10",
           "conditions": [],
           "actions": [
             {
@@ -907,10 +1124,10 @@
           ]
         },
         {
-          "name": "as65550-peer-out2-tyo-ipv4-20",
+          "name": "as65560-peer-out1-tyo-ipv4-20",
           "conditions": [
             {
-              "policy": "if-condition-as65550-peer-out2-tyo-ipv4-20"
+              "policy": "if-condition-as65560-peer-out1-tyo-ipv4-20"
             }
           ],
           "actions": [
@@ -929,7 +1146,7 @@
           ]
         },
         {
-          "name": "as65550-peer-out2-tyo-ipv4-30",
+          "name": "as65560-peer-out1-tyo-ipv4-30",
           "conditions": [],
           "actions": [
             {
@@ -969,8 +1186,8 @@
   ],
   "bgp_neighbors": [
     {
-      "remote_as": "65520",
-      "remote_ip": "192.168.0.18",
+      "remote_as": "65550",
+      "remote_ip": "172.16.0.9",
       "address_families": [
         {
           "afi": "ipv4",
@@ -978,14 +1195,29 @@
           "send_community_ebgp": true,
           "next_hop_self": true,
           "remove_private_as": true,
-          "route_policy_in": "POI-East_in",
-          "route_policy_out": ""
+          "route_policy_in": "as65550-peer-in1-tyo-ipv4",
+          "route_policy_out": "as65550-peer-out1-tyo-ipv4"
+        }
+      ]
+    },
+    {
+      "remote_as": "65560",
+      "remote_ip": "172.16.1.9",
+      "address_families": [
+        {
+          "afi": "ipv4",
+          "safi": "unicast",
+          "send_community_ebgp": true,
+          "next_hop_self": true,
+          "remove_private_as": true,
+          "route_policy_in": "as65560-peer-in1-tyo-ipv4",
+          "route_policy_out": "as65560-peer-out1-tyo-ipv4"
         }
       ]
     },
     {
       "remote_as": "65500",
-      "remote_ip": "192.168.255.1",
+      "remote_ip": "192.168.255.101",
       "address_families": [
         {
           "afi": "ipv4",
@@ -1000,7 +1232,7 @@
     },
     {
       "remote_as": "65500",
-      "remote_ip": "192.168.255.2",
+      "remote_ip": "192.168.255.102",
       "address_families": [
         {
           "afi": "ipv4",

--- a/test/expects/cisco_ios_xr/ttp.json
+++ b/test/expects/cisco_ios_xr/ttp.json
@@ -13,7 +13,7 @@
         {
           "name": "Loopback0",
           "ipv4": {
-            "address": "192.168.255.7",
+            "address": "192.168.255.2",
             "mask": "255.255.255.255"
           }
         },
@@ -27,23 +27,29 @@
         {
           "name": "GigabitEthernet0/0/0/0",
           "ipv4": {
-            "address": "192.168.1.5",
+            "address": "192.168.1.2",
             "mask": "255.255.255.0"
           }
         },
         {
-          "name": "GigabitEthernet0/0/0/1",
+          "name": "GigabitEthernet0/0/0/1"
+        },
+        {
+          "name": "GigabitEthernet0/0/0/1.100",
           "ipv4": {
-            "address": "192.168.0.17",
+            "address": "172.16.0.10",
             "mask": "255.255.255.252"
           }
         },
         {
-          "name": "GigabitEthernet0/0/0/2",
+          "name": "GigabitEthernet0/0/0/1.200",
           "ipv4": {
-            "address": "172.16.1.18",
+            "address": "172.16.1.10",
             "mask": "255.255.255.252"
           }
+        },
+        {
+          "name": "GigabitEthernet0/0/0/2"
         },
         {
           "name": "GigabitEthernet0/0/0/3"
@@ -423,14 +429,6 @@
       ],
       "prefix-sets": [
         {
-          "name": "as65550-advd",
-          "prefixes": [
-            {
-              "prefix": "10.100.0.0/16"
-            }
-          ]
-        },
-        {
           "name": "default-ipv4",
           "prefixes": [
             {
@@ -446,6 +444,40 @@
               "condition": "ge 25"
             }
           ]
+        },
+        {
+          "name": "as65550-advd-ipv4",
+          "prefixes": [
+            {
+              "prefix": "10.100.0.0/16"
+            },
+            {
+              "prefix": "10.110.0.0/20"
+            },
+            {
+              "prefix": "10.120.0.0/17"
+            },
+            {
+              "prefix": "10.130.0.0/21"
+            }
+          ]
+        },
+        {
+          "name": "as65560-advd-ipv4",
+          "prefixes": [
+            {
+              "prefix": "10.100.0.0/16"
+            },
+            {
+              "prefix": "10.110.0.0/20"
+            },
+            {
+              "prefix": "10.120.0.0/17"
+            },
+            {
+              "prefix": "10.130.0.0/21"
+            }
+          ]
         }
       ],
       "as-path-sets": [
@@ -458,21 +490,18 @@
           ]
         },
         {
-          "name": "multiple-regex",
-          "conditions": [
-            {
-              "pattern": "^(65001_)+$"
-            },
-            {
-              "pattern": "^(65002_)+$"
-            }
-          ]
-        },
-        {
           "name": "as65550-origin",
           "conditions": [
             {
               "pattern": "^(65550_)+$"
+            }
+          ]
+        },
+        {
+          "name": "as65560-origin",
+          "conditions": [
+            {
+              "pattern": "^(65560_)+$"
             }
           ]
         },
@@ -532,11 +561,6 @@
         {
           "name": "POI-East_in",
           "rules": [
-            {
-              "action": "prepend",
-              "attr": "as-path",
-              "value": "50000 2"
-            },
             {
               "action": "set",
               "attr": "med",
@@ -665,11 +689,6 @@
               },
               "rules": [
                 {
-                  "action": "prepend",
-                  "attr": "as-path",
-                  "value": "60000"
-                },
-                {
                   "action": "set",
                   "attr": "local-preference",
                   "value": "300"
@@ -733,9 +752,10 @@
             {
               "if": "if",
               "condition": {
-                "op": "state",
+                "op": "and",
                 "matches": [
-                  "community matches-any aggregate"
+                  "community matches-any aggregate",
+                  "destination in as65550-advd-ipv4"
                 ]
               },
               "rules": [
@@ -760,7 +780,77 @@
           ]
         },
         {
-          "name": "as65550-peer-out2-tyo-ipv4",
+          "name": "as65560-peer-in1-tyo-ipv4",
+          "rules": [
+            {
+              "action": "apply",
+              "value": "reject-in-ipv4"
+            },
+            {
+              "if": "if",
+              "condition": {
+                "op": "state",
+                "matches": [
+                  "as-path in as65560-origin"
+                ]
+              },
+              "rules": [
+                {
+                  "action": "set",
+                  "attr": "local-preference",
+                  "value": "300"
+                },
+                {
+                  "action": "set",
+                  "attr": "med",
+                  "value": "100"
+                },
+                {
+                  "action": "set",
+                  "attr": "community",
+                  "value": "peer"
+                },
+                {
+                  "action": "done"
+                }
+              ]
+            },
+            {
+              "if": "if",
+              "condition": {
+                "op": "state",
+                "matches": [
+                  "as-path in any"
+                ]
+              },
+              "rules": [
+                {
+                  "action": "set",
+                  "attr": "local-preference",
+                  "value": "210"
+                },
+                {
+                  "action": "set",
+                  "attr": "med",
+                  "value": "100"
+                },
+                {
+                  "action": "set",
+                  "attr": "community",
+                  "value": "peer"
+                },
+                {
+                  "action": "done"
+                }
+              ]
+            },
+            {
+              "action": "drop"
+            }
+          ]
+        },
+        {
+          "name": "as65560-peer-out1-tyo-ipv4",
           "rules": [
             {
               "action": "apply",
@@ -772,7 +862,7 @@
                 "op": "and",
                 "matches": [
                   "community matches-any aggregate",
-                  "destination in as65550-advd"
+                  "destination in as65560-advd-ipv4"
                 ]
               },
               "rules": [
@@ -810,14 +900,14 @@
           }
         ],
         "router-id": {
-          "router-id": "192.168.255.7"
+          "router-id": "192.168.255.2"
         },
         "af_ipv4_unicast": {},
         "neighbors": [
           {
-            "remote-as": "65520",
-            "remote-ip": "192.168.0.18",
-            "description": "POI-East",
+            "remote-as": "65550",
+            "remote-ip": "172.16.0.9",
+            "description": "AS65550_PNI1-2_ipv4",
             "address-families": [
               {
                 "afi": "ipv4",
@@ -835,7 +925,36 @@
                     }
                   ],
                   "route-policy": {
-                    "in": "POI-East_in"
+                    "out": "as65550-peer-out1-tyo-ipv4",
+                    "in": "as65550-peer-in1-tyo-ipv4"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "remote-as": "65560",
+            "remote-ip": "172.16.1.9",
+            "description": "AS65560_PNI2-1_ipv4",
+            "address-families": [
+              {
+                "afi": "ipv4",
+                "safi": "unicast",
+                "configs": {
+                  "attrs": [
+                    {
+                      "value": "send-community-ebgp"
+                    },
+                    {
+                      "value": "next-hop-self"
+                    },
+                    {
+                      "value": "remove-private-AS"
+                    }
+                  ],
+                  "route-policy": {
+                    "out": "as65560-peer-out1-tyo-ipv4",
+                    "in": "as65560-peer-in1-tyo-ipv4"
                   }
                 }
               }
@@ -844,7 +963,7 @@
           {
             "update-source": "Loopback0",
             "remote-as": "65500",
-            "remote-ip": "192.168.255.1",
+            "remote-ip": "192.168.255.101",
             "description": "RR",
             "address-families": [
               {
@@ -863,7 +982,7 @@
           {
             "update-source": "Loopback0",
             "remote-as": "65500",
-            "remote-ip": "192.168.255.2",
+            "remote-ip": "192.168.255.102",
             "description": "RR",
             "address-families": [
               {

--- a/test/inputs/cisco_ios_xr.conf
+++ b/test/inputs/cisco_ios_xr.conf
@@ -3,25 +3,33 @@ Building configuration...
 !! IOS XR Configuration 5.3.2
 !! Last configuration change at Tue Oct 31 04:30:24 2023 by vrnetlab
 !
-hostname Edge-TK03
+hostname Edge-TK02
 interface Loopback0
- ipv4 address 192.168.255.7 255.255.255.255
+ ipv4 address 192.168.255.2 255.255.255.255
 !
 interface MgmtEth0/0/CPU0/0
  ipv4 address 10.0.0.15 255.255.255.0
  shutdown
 !
 interface GigabitEthernet0/0/0/0
- description to_SW-TK01_Ethernet5
- ipv4 address 192.168.1.5 255.255.255.0
+ description to_SW-TK01_Ethernet4
+ ipv4 address 192.168.1.2 255.255.255.0
 !
 interface GigabitEthernet0/0/0/1
- description to_POI-East_Ethernet7
- ipv4 address 192.168.0.17 255.255.255.252
+ description to_shared_curcuit
+!
+interface GigabitEthernet0/0/0/1.100
+ description to_PNI01-2
+ ipv4 address 172.16.0.10 255.255.255.252
+ encapsulation dot1q 100
+!
+interface GigabitEthernet0/0/0/1.200
+ description to_PNI02-1
+ ipv4 address 172.16.1.10 255.255.255.252
+ encapsulation dot1q 200
 !
 interface GigabitEthernet0/0/0/2
- description to_PNI02_Ethernet4
- ipv4 address 172.16.1.18 255.255.255.252
+ shutdown
 !
 interface GigabitEthernet0/0/0/3
  shutdown
@@ -398,10 +406,6 @@ interface GigabitEthernet0/0/0/126
 interface GigabitEthernet0/0/0/127
  shutdown
 !
-prefix-set as65550-advd
-  10.100.0.0/16
-end-set
-!
 prefix-set default-ipv4
   0.0.0.0/0
 end-set
@@ -410,17 +414,30 @@ prefix-set longer24-ipv4
   0.0.0.0/0 ge 25
 end-set
 !
+prefix-set as65550-advd-ipv4
+  10.100.0.0/16
+  10.110.0.0/20
+  10.120.0.0/17
+  10.130.0.0/21
+end-set
+!
+prefix-set as65560-advd-ipv4
+  10.100.0.0/16
+  10.110.0.0/20
+  10.120.0.0/17
+  10.130.0.0/21
+end-set
+!
 as-path-set any
   ios-regex '.*'
 end-set
 !
-as-path-set multiple-regex
-  ios-regex '^(65001_)+$'
-  ios-regex '^(65002_)+$'
-end-set
-!
 as-path-set as65550-origin
   ios-regex '^(65550_)+$'
+end-set
+!
+as-path-set as65560-origin
+  ios-regex '^(65560_)+$'
 end-set
 !
 as-path-set aspath-longer200
@@ -448,7 +465,6 @@ community-set as65518-any
 end-set
 !
 route-policy POI-East_in
-  prepend as-path 50000 2
   set med 100
   set local-preference 300
   delete community in any
@@ -482,7 +498,6 @@ end-policy
 route-policy as65550-peer-in1-tyo-ipv4
   apply reject-in-ipv4
   if as-path in as65550-origin then
-    prepend as-path 60000
     set local-preference 300
     set med 100
     set community peer
@@ -499,7 +514,7 @@ end-policy
 !
 route-policy as65550-peer-out1-tyo-ipv4
   apply reject-out-ipv4
-  if community matches-any aggregate then
+  if community matches-any aggregate and destination in as65550-advd-ipv4 then
     set med 100
     delete community in any
     done
@@ -507,9 +522,26 @@ route-policy as65550-peer-out1-tyo-ipv4
   drop
 end-policy
 !
-route-policy as65550-peer-out2-tyo-ipv4
+route-policy as65560-peer-in1-tyo-ipv4
+  apply reject-in-ipv4
+  if as-path in as65560-origin then
+    set local-preference 300
+    set med 100
+    set community peer
+    done
+  endif
+  if as-path in any then
+    set local-preference 210
+    set med 100
+    set community peer
+    done
+  endif
+  drop
+end-policy
+!
+route-policy as65560-peer-out1-tyo-ipv4
   apply reject-out-ipv4
-  if community matches-any aggregate and destination in as65550-advd then
+  if community matches-any aggregate and destination in as65560-advd-ipv4 then
     set med 100
     delete community in any
     done
@@ -523,7 +555,7 @@ router static
  !
 !
 router ospf 65500
- area 0.0.0.10
+ area 0.0.0.0
   interface Loopback0
    cost 1
   !
@@ -535,22 +567,36 @@ router ospf 65500
 router bgp 65500
  bgp confederation identifier 65518
  bgp confederation peers 65500
- bgp router-id 192.168.255.7
+ bgp router-id 192.168.255.2
  address-family ipv4 unicast
  !
- neighbor 192.168.0.18
-  remote-as 65520
+ neighbor 172.16.0.9
+  remote-as 65550
   timers 10 30
-  description "POI-East"
+  description "AS65550_PNI1-2_ipv4"
   address-family ipv4 unicast
    send-community-ebgp
-   route-policy POI-East_in in
+   route-policy as65550-peer-in1-tyo-ipv4 in
+   route-policy as65550-peer-out1-tyo-ipv4 out
    next-hop-self
    remove-private-AS
    soft-reconfiguration inbound always
   !
  !
- neighbor 192.168.255.1
+ neighbor 172.16.1.9
+  remote-as 65560
+  timers 10 30
+  description "AS65560_PNI2-1_ipv4"
+  address-family ipv4 unicast
+   send-community-ebgp
+   route-policy as65560-peer-in1-tyo-ipv4 in
+   route-policy as65560-peer-out1-tyo-ipv4 out
+   next-hop-self
+   remove-private-AS
+   soft-reconfiguration inbound always
+  !
+ !
+ neighbor 192.168.255.101
   remote-as 65500
   password encrypted 0506020B2E
   description RR
@@ -559,7 +605,7 @@ router bgp 65500
    next-hop-self
   !
  !
- neighbor 192.168.255.2
+ neighbor 192.168.255.102
   remote-as 65500
   password encrypted 0506020B2E
   description RR


### PR DESCRIPTION
iosxr prefix-listがexactのみの場合、prefix-listを展開せずにポリシーモデルに追加する処理を追加